### PR TITLE
Allow bookend to only contain a footer

### DIFF
--- a/assets/jquery.alton.js
+++ b/assets/jquery.alton.js
@@ -111,8 +111,10 @@
       previous = null;
       current = next;
       next = current.next();
-      last = $('.' + singleSlideClass + ':last-child')[0];
     }
+    if (!$('.' + settings.lastClass).length) {
+	    last = $('.' + singleSlideClass + ':last-child')[0];
+	  }
 
     /* =============================================================================
      * Position Variables


### PR DESCRIPTION
Bookend forces there to be both a header and footer. I needed a bookend that was only a footer. The code previously overwrote the last variable if the firstClass didn't exist. I decoupled the lastClass logic from the firstClass logic so we could have a standalone header bookend and a standalone footer bookend.
