### PR TITLE
Add animation duration support

### DIFF
--- a/assets/jquery.alton.js
+++ b/assets/jquery.alton.js
@@ -61,7 +61,8 @@
     useSlideNumbers: false, // Enable or disable slider
     slideNumbersBorderColor: '#fff', // outside color for slide numbers
     slideNumbersColor: '#000', // interior color when slide numbers inactive
-    animationType: 'slow', // animation type: currently doesn't do anything
+    animationType: 'slow', // animation type: currently doesn't do anything,
+    animationDuration: 375,
     callback: false, // default is no callback
   };
 
@@ -524,13 +525,13 @@
         $("body,html").stop(true, true).animate({
           scrollTop: $(element).offset().top
         }, {
-          duration: 375
+          duration: settings.animationDuration
         });
       } else {
         $("body,html").stop(true, true).animate({
           scrollTop: $(document).outerHeight() - windowHeight
         }, {
-          duration: 375
+          duration: settings.animationDuration
         });
       }
     };


### PR DESCRIPTION
Add animationDuration to default config variables and replace the animation duration by the variable.
It can be used in the init function.

```javascript
$(document).alton({
	fullSlideContainer: 'full', // Tell Alton the full height container
	singleSlideClass: 'slide', // Tell Alton the full height slide class
	useSlideNumbers: true, // Set to false if you don't want to use pagination
	slideNumbersBorderColor: '#fff', // Set the outside color of the pagination items (also used for active)
	slideNumbersColor: 'transparent', // Set the inner color of the pagination items (not active)
	bodyContainer: 'pageWrapper', // Tell Alton the body class,
	animationDuration: 375, //Animation duration (in ms).
});
```